### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CuteLoadingLayoutGit
-####Author:Ezreal Wang
-####Blog:[http://blog.csdn.net/ddwhan0123](http://blog.csdn.net/ddwhan0123) 
+#### Author:Ezreal Wang
+#### Blog:[http://blog.csdn.net/ddwhan0123](http://blog.csdn.net/ddwhan0123) 
 演示效果：<br>
 ![Demo](https://raw.githubusercontent.com/ddwhan0123/CuteLoadingLayoutGit/master/CuteLoadingView/coco.gif "效果")
 <br>


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
